### PR TITLE
Add batch basket item endpoint

### DIFF
--- a/healthri-basket-api.test/healthri-basket-api.test/Controller.Tests/BasketControllerTests.cs
+++ b/healthri-basket-api.test/healthri-basket-api.test/Controller.Tests/BasketControllerTests.cs
@@ -393,6 +393,85 @@ namespace healthri_basket_api.test.Controller.Tests
         }
 
         [Fact]
+        public async Task AddItems_WhenItemsAreAddedSuccessfully_ReturnsOkWithUpdatedBasket()
+        {
+            // Arrange
+            Guid basketId = Guid.NewGuid();
+            Basket expectedBasket = CreateBasketWithItems(basketId);
+            string[] itemIds = ["item-a", "item-b"];
+            expectedBasket.ClearItems();
+            foreach (var itemId in itemIds)
+            {
+                expectedBasket.AddItem(itemId);
+            }
+
+            _basketServiceMock
+                .Setup(s => s.AddItemsAsync(expectedBasket.UserId, expectedBasket.Slug, itemIds, BasketItemSource.CatalogPage, _ct))
+                .ReturnsAsync(expectedBasket);
+
+            SetAuthenticatedUser(expectedBasket.UserId);
+
+            // Act
+            IActionResult result = await _basketController.AddItems(expectedBasket.Slug, itemIds, _ct);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedBasket = Assert.IsType<Basket>(okResult.Value);
+
+            Assert.Equal(expectedBasket, returnedBasket);
+            Assert.Equal(itemIds, returnedBasket.Items.Select(i => i.ItemId));
+        }
+
+        [Fact]
+        public async Task AddItems_WhenBasketDoesNotExist_ReturnsNotFound()
+        {
+            // Arrange
+            string slug = "test-slug";
+            Guid userId = Guid.NewGuid();
+            string[] itemIds = ["item-404"];
+
+            _basketServiceMock
+                .Setup(s => s.AddItemsAsync(userId, slug, itemIds, BasketItemSource.CatalogPage, _ct))
+                .ReturnsAsync((Basket?)null);
+
+            SetAuthenticatedUser(userId);
+
+            // Act
+            IActionResult result = await _basketController.AddItems(slug, itemIds, _ct);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        public static IEnumerable<object?[]> InvalidAddItemsPayloads =>
+        [
+            [null],
+            [Array.Empty<string>()],
+            [new[] { "", " " }],
+        ];
+
+        [Theory]
+        [MemberData(nameof(InvalidAddItemsPayloads))]
+        public async Task AddItems_WhenPayloadHasNoValidItems_ReturnsBadRequest(string[]? itemIds)
+        {
+            // Arrange
+            Guid userId = Guid.NewGuid();
+            SetAuthenticatedUser(userId);
+
+            // Act
+            IActionResult result = await _basketController.AddItems("test-slug", itemIds, _ct);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(result);
+            _basketServiceMock.Verify(s => s.AddItemsAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<BasketItemSource>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
         public async Task RemoveItem_WhenItemIsRemovedSuccessfully_ReturnsOk()
         {
             // Arrange

--- a/healthri-basket-api.test/healthri-basket-api.test/Repositories.Tests/BasketRepositoryTests.cs
+++ b/healthri-basket-api.test/healthri-basket-api.test/Repositories.Tests/BasketRepositoryTests.cs
@@ -79,6 +79,30 @@ public class BasketRepositoryTests
     }
 
     [Fact]
+    public async Task AddItemsAsync_WhenCalled_AddsBasketItems()
+    {
+        using var context = CreateContext();
+        var repo = new BasketRepository(context);
+        var basket = new Basket(Guid.NewGuid(), "basket", "Basket", false);
+        context.Baskets.Add(basket);
+        await context.SaveChangesAsync();
+
+        var basketItems = new[]
+        {
+            new BasketItem(basket, "item-1"),
+            new BasketItem(basket, "item-2"),
+        };
+
+        await repo.AddItemsAsync(basketItems, CancellationToken.None);
+
+        var savedItemIds = await context.BasketItems
+            .Where(bi => bi.BasketId == basket.Id)
+            .Select(bi => bi.ItemId)
+            .ToListAsync();
+        Assert.Equal(["item-1", "item-2"], savedItemIds);
+    }
+
+    [Fact]
     public async Task RemoveItemAsync_WhenCalled_RemovesBasketItem()
     {
         using var context = CreateContext();

--- a/healthri-basket-api.test/healthri-basket-api.test/Services.Tests/BasketServiceTests.cs
+++ b/healthri-basket-api.test/healthri-basket-api.test/Services.Tests/BasketServiceTests.cs
@@ -513,6 +513,163 @@ namespace healthri_basket_api.test.Services.Tests
         }
 
         [Fact]
+        public async Task AddItemsAsync_WhenItemsAndBasketExist_ReturnsUpdatedBasketAndAddsItems()
+        {
+            // Arrange
+            Guid basketId = Guid.NewGuid();
+            string[] itemIds = ["item-4", "item-5"];
+            BasketItemSource source = BasketItemSource.CatalogPage;
+            var basket = CreateBasketWithItems(basketId);
+            basket.Items.Clear();
+
+            _basketRepositoryMock
+                .Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct))
+                .ReturnsAsync(basket);
+            _basketRepositoryMock
+                .Setup(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct))
+                .ReturnsAsync(true);
+
+            // Act
+            Basket? result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, itemIds, source, _ct);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(itemIds, result.Items.Select(i => i.ItemId));
+
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.Is<IEnumerable<BasketItem>>(
+                items => items.Select(i => i.ItemId).SequenceEqual(itemIds) && items.All(i => i.BasketId == basket.Id)
+            ), _ct), Times.Once);
+
+            foreach (var itemId in itemIds)
+            {
+                _loggerMock.Verify(l => l.LogAsync(basket.UserId, basketId, itemId, BasketAction.AddItem, source), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task AddItemsAsync_WhenSomeItemsAlreadyExist_AddsOnlyNewItems()
+        {
+            // Arrange
+            Guid basketId = Guid.NewGuid();
+            BasketItemSource source = BasketItemSource.CatalogPage;
+            var basket = CreateBasketWithItems(basketId);
+            string existingItemId = basket.Items.First().ItemId;
+            string newItemId = "item-4";
+            string[] itemIds = [existingItemId, newItemId];
+
+            _basketRepositoryMock
+                .Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct))
+                .ReturnsAsync(basket);
+            _basketRepositoryMock
+                .Setup(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct))
+                .ReturnsAsync(true);
+
+            // Act
+            Basket? result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, itemIds, source, _ct);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Contains(result.Items, i => i.ItemId == existingItemId);
+            Assert.Contains(result.Items, i => i.ItemId == newItemId);
+
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.Is<IEnumerable<BasketItem>>(
+                items => items.Single().ItemId == newItemId
+            ), _ct), Times.Once);
+            _loggerMock.Verify(l => l.LogAsync(basket.UserId, basketId, newItemId, BasketAction.AddItem, source), Times.Once);
+            _loggerMock.Verify(l => l.LogAsync(basket.UserId, basketId, existingItemId, BasketAction.AddItem, source), Times.Never);
+        }
+
+        [Fact]
+        public async Task AddItemsAsync_WhenRequestContainsDuplicateItems_AddsEachItemOnce()
+        {
+            // Arrange
+            Guid basketId = Guid.NewGuid();
+            BasketItemSource source = BasketItemSource.CatalogPage;
+            var basket = CreateBasketWithItems(basketId);
+            basket.Items.Clear();
+            string[] itemIds = ["item-4", "item-4", "item-5"];
+
+            _basketRepositoryMock
+                .Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct))
+                .ReturnsAsync(basket);
+            _basketRepositoryMock
+                .Setup(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct))
+                .ReturnsAsync(true);
+
+            // Act
+            Basket? result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, itemIds, source, _ct);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(["item-4", "item-5"], result.Items.Select(i => i.ItemId));
+
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.Is<IEnumerable<BasketItem>>(
+                items => items.Select(i => i.ItemId).SequenceEqual(new[] { "item-4", "item-5" })
+            ), _ct), Times.Once);
+            _loggerMock.Verify(l => l.LogAsync(basket.UserId, basketId, "item-4", BasketAction.AddItem, source), Times.Once);
+            _loggerMock.Verify(l => l.LogAsync(basket.UserId, basketId, "item-5", BasketAction.AddItem, source), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddItemsAsync_WhenAllItemsAlreadyExist_ReturnsBasketWithoutRepositoryOrLogging()
+        {
+            // Arrange
+            Guid basketId = Guid.NewGuid();
+            BasketItemSource source = BasketItemSource.CatalogPage;
+            var basket = CreateBasketWithItems(basketId);
+            string[] itemIds = basket.Items.Select(i => i.ItemId).ToArray();
+
+            _basketRepositoryMock
+                .Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct))
+                .ReturnsAsync(basket);
+
+            // Act
+            Basket? result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, itemIds, source, _ct);
+
+            // Assert
+            Assert.Equal(basket, result);
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct), Times.Never);
+            _loggerMock.Verify(l => l.LogAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<BasketAction>(), It.IsAny<BasketItemSource>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AddItemsAsync_WhenBasketNotFound_ReturnsNull()
+        {
+            // Arrange
+            Guid userId = Guid.NewGuid();
+            string slug = "missing-basket";
+            string[] itemIds = ["item-1"];
+            _basketRepositoryMock.Setup(r => r.GetBySlugAsync(userId, slug, _ct)).ReturnsAsync((Basket?)null);
+
+            // Act
+            var result = await _basketService.AddItemsAsync(userId, slug, itemIds, BasketItemSource.UserPage, _ct);
+
+            // Assert
+            Assert.Null(result);
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct), Times.Never);
+            _loggerMock.Verify(l => l.LogAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<BasketAction>(), It.IsAny<BasketItemSource>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AddItemsAsync_WhenUserMismatch_ReturnsNull()
+        {
+            // Arrange
+            Guid userId = Guid.NewGuid();
+            string slug = "basket";
+            string[] itemIds = ["item-1"];
+            Basket basket = new Basket(Guid.NewGuid(), slug, "Basket", false);
+            _basketRepositoryMock.Setup(r => r.GetBySlugAsync(userId, slug, _ct)).ReturnsAsync(basket);
+
+            // Act
+            var result = await _basketService.AddItemsAsync(userId, slug, itemIds, BasketItemSource.UserPage, _ct);
+
+            // Assert
+            Assert.Null(result);
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct), Times.Never);
+            _loggerMock.Verify(l => l.LogAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<BasketAction>(), It.IsAny<BasketItemSource>()), Times.Never);
+        }
+
+        [Fact]
         public async Task RemoveItemAsync_WhenItemExistsInBasket_ReturnsTrueAndRemovesItem()
         {
             // Arrange

--- a/healthri-basket-api/Controllers/BasketsController.cs
+++ b/healthri-basket-api/Controllers/BasketsController.cs
@@ -144,6 +144,27 @@ public class BasketsController(IBasketService service) : ControllerBase
         return NotFound();
     }
 
+    [HttpPost("{slug}/items/batch")]
+    [ProducesResponseType(typeof(Basket), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> AddItems(string slug, [FromBody] IEnumerable<string>? itemIds, CancellationToken ct)
+    {
+        if (!TryGetUserId(out var userId, out var error))
+            return error!;
+
+        if (itemIds == null)
+            return BadRequest("At least one item ID is required.");
+
+        var itemIdsList = itemIds.ToList();
+        if (itemIdsList.Count == 0 || itemIdsList.All(string.IsNullOrWhiteSpace))
+            return BadRequest("At least one item ID is required.");
+
+        var result = await service.AddItemsAsync(userId, slug, itemIdsList, BasketItemSource.CatalogPage, ct);
+        return result != null ? Ok(result) : NotFound();
+    }
+
     [HttpDelete("{slug}/items")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/healthri-basket-api/Interfaces/IBasketRepository.cs
+++ b/healthri-basket-api/Interfaces/IBasketRepository.cs
@@ -7,6 +7,7 @@ public interface IBasketRepository
     Task<List<Basket>> GetByUserIdAsync(Guid userId, CancellationToken ct);
     Task<Basket?> GetBySlugAsync(Guid userId, string slug, CancellationToken ct);
     Task<bool> AddItemAsync(BasketItem basketItem, CancellationToken ct);
+    Task<bool> AddItemsAsync(IEnumerable<BasketItem> basketItems, CancellationToken ct);
     Task<bool> RemoveItemAsync(BasketItem basketItem, CancellationToken ct);
     Task<Basket> CreateAsync(Basket basket, CancellationToken ct);
     Task<Basket> UpdateAsync(Basket basket, CancellationToken ct);

--- a/healthri-basket-api/Interfaces/IBasketService.cs
+++ b/healthri-basket-api/Interfaces/IBasketService.cs
@@ -14,5 +14,6 @@ public interface IBasketService
     Task<bool> ArchiveAsync(Guid userId, string slug, CancellationToken ct);
     Task<bool> ClearAsync(Guid userId, string slug, CancellationToken ct);
     Task<Basket?> AddItemAsync(Guid userId, string slug, string itemId, BasketItemSource source, CancellationToken ct);
+    Task<Basket?> AddItemsAsync(Guid userId, string slug, IEnumerable<string> itemIds, BasketItemSource source, CancellationToken ct);
     Task<bool> RemoveItemAsync(Guid userId, string slug, string itemId, BasketItemSource source, CancellationToken ct);
 }

--- a/healthri-basket-api/Repositories/BasketRepository.cs
+++ b/healthri-basket-api/Repositories/BasketRepository.cs
@@ -35,6 +35,13 @@ public class BasketRepository(AppDbContext context) : IBasketRepository
         return true;
     }
 
+    public async Task<bool> AddItemsAsync(IEnumerable<BasketItem> basketItems, CancellationToken ct)
+    {
+        await context.BasketItems.AddRangeAsync(basketItems, ct);
+        await context.SaveChangesAsync(ct);
+        return true;
+    }
+
     public async Task<bool> RemoveItemAsync(BasketItem basketItem, CancellationToken ct)
     {
         context.BasketItems.Remove(basketItem);

--- a/healthri-basket-api/Services/BasketService.cs
+++ b/healthri-basket-api/Services/BasketService.cs
@@ -179,6 +179,47 @@ public class BasketService(
         return basket;
     }
 
+    public async Task<Basket?> AddItemsAsync(Guid userId, string slug, IEnumerable<string> itemIds, BasketItemSource source, CancellationToken ct)
+    {
+        var uniqueItemIds = itemIds
+            .Where(itemId => !string.IsNullOrWhiteSpace(itemId))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (uniqueItemIds.Count == 0)
+        {
+            return null;
+        }
+
+        Basket? basket = await basketRepository.GetBySlugAsync(userId, slug, ct);
+        if (basket == null || basket.UserId != userId)
+            return null;
+
+        var basketItems = uniqueItemIds
+            .Where(itemId => !basket.HasItem(itemId))
+            .Select(itemId => new BasketItem(basket, itemId))
+            .ToList();
+
+        if (basketItems.Count == 0)
+        {
+            return basket;
+        }
+
+        await basketRepository.AddItemsAsync(basketItems, ct);
+
+        foreach (var basketItem in basketItems)
+        {
+            if (basket.Items.All(i => i.Id != basketItem.Id))
+            {
+                basket.Items.Add(basketItem);
+            }
+
+            await logger.LogAsync(basket.UserId, basket.Id, basketItem.ItemId, BasketAction.AddItem, source);
+        }
+
+        return basket;
+    }
+
     public async Task<bool> RemoveItemAsync(Guid userId, string slug, string itemId, BasketItemSource source, CancellationToken ct)
     {
         Basket? basket = await basketRepository.GetBySlugAsync(userId, slug, ct);

--- a/healthri-basket-api/healthri-basket-api.http
+++ b/healthri-basket-api/healthri-basket-api.http
@@ -12,13 +12,21 @@ Content-Type: application/json
 "My Sample Basket"
 
 ###
-# Add item to basket
-POST {{healthri_basket_api_HostAddress}}/api/v1/baskets/{basketId}/items
+# Add single item to basket
+POST {{healthri_basket_api_HostAddress}}/api/v1/baskets/{slug}/items
 Content-Type: application/json
 
-{
-  "itemId": "dataset-123",
-  "source": "catalog_page"
-}
+"dataset-123"
+
+###
+# Add multiple items to basket
+POST {{healthri_basket_api_HostAddress}}/api/v1/baskets/{slug}/items/batch
+Content-Type: application/json
+
+[
+  "dataset-123",
+  "dataset-456",
+  "dataset-789"
+]
 
 ###


### PR DESCRIPTION
## Summary

Adds a batch endpoint for adding multiple datasets to a basket while preserving the existing single-item endpoint.

## Changes

- Adds `POST /api/v1/baskets/{slug}/items/batch` accepting a JSON string array.
- Adds service and repository batch methods that persist new basket items in one save.
- Keeps batch duplicate handling idempotent by skipping repeated or already-present item IDs.
- Logs one `AddItem` transaction per newly added dataset.
- Updates HTTP examples for single and batch item adds.

## Validation

- `dotnet test healthri-basket-api.sln --no-restore` passed: 62 tests.

## Summary by Sourcery

Add support for adding multiple items to a basket in a single batch operation while preserving existing single-item behavior.

New Features:
- Introduce a batch basket items API endpoint to add multiple item IDs to a basket in one request.
- Add service and repository methods to persist multiple basket items in a single operation with idempotent handling of duplicates and existing items.

Tests:
- Add service tests covering batch add behavior, including duplicates, pre-existing items, missing baskets, and user mismatches.
- Add controller tests for the batch add endpoint covering success, not-found, and invalid payload scenarios.
- Add repository tests verifying that multiple basket items are saved correctly in a single batch operation.