### PR TITLE
 feat: replace single-item add endpoint with multi-item support

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,9 +7,9 @@
       dockerfile: ./healthri-basket-api/Dockerfile
     ports:
       - "8081:8080"
-    env_file: 
-        - path: ./healthri-basket-api/.env
-          required: true
+    env_file:
+      - path: ./healthri-basket-api/.env
+        required: true
     depends_on: [keycloak, db, adminer]
 
   keycloak:

--- a/healthri-basket-api.test/healthri-basket-api.test/Controller.Tests/BasketControllerTests.cs
+++ b/healthri-basket-api.test/healthri-basket-api.test/Controller.Tests/BasketControllerTests.cs
@@ -320,23 +320,23 @@ namespace healthri_basket_api.test.Controller.Tests
         }
 
         [Fact]
-        public async Task AddItem_WhenItemIsAddedSuccessfully_ReturnsOkWithUpdatedBasket()
+        public async Task AddItems_WhenNewItems_ReturnsOkWithUpdatedBasket()
         {
             // Arrange
             Guid basketId = Guid.NewGuid();
             Basket expectedBasket = CreateBasketWithItems(basketId);
             string itemId = "item-a";
-            expectedBasket.ClearItems(); // Start with an empty basket for this test
+            expectedBasket.ClearItems();
             expectedBasket.AddItem(itemId);
 
             _basketServiceMock
-                .Setup(s => s.AddItemAsync(expectedBasket.UserId, expectedBasket.Slug, itemId, BasketItemSource.CatalogPage, _ct))
+                .Setup(s => s.AddItemsAsync(expectedBasket.UserId, expectedBasket.Slug, It.Is<IEnumerable<string>>(ids => ids.Single() == itemId), BasketItemSource.CatalogPage, _ct))
                 .ReturnsAsync(expectedBasket);
 
             SetAuthenticatedUser(expectedBasket.UserId);
 
             // Act
-            IActionResult result = await _basketController.AddItem(expectedBasket.Slug, itemId, _ct);
+            IActionResult result = await _basketController.AddItems(expectedBasket.Slug, new AddItemsDTO { ItemIds = new[] { itemId } }, _ct);
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
@@ -346,28 +346,27 @@ namespace healthri_basket_api.test.Controller.Tests
             Assert.Equal(itemId, returnedBasket.Items[0].ItemId);
         }
 
-
         [Fact]
-        public async Task AddItem_WhenItemOrBasketDoesNotExist_ReturnsNotFound()
+        public async Task AddItems_WhenBasketDoesNotExist_ReturnsNotFound()
         {
             // Arrange
             string slug = "test-slug";
             Guid userId = Guid.NewGuid();
             string itemId = "item-404";
 
-            _basketServiceMock.Setup(s => s.AddItemAsync(userId, slug, itemId, BasketItemSource.CatalogPage, _ct));
+            _basketServiceMock.Setup(s => s.AddItemsAsync(userId, slug, It.IsAny<IEnumerable<string>>(), BasketItemSource.CatalogPage, _ct));
 
             SetAuthenticatedUser(userId);
 
             // Act
-            IActionResult result = await _basketController.AddItem(slug, itemId, _ct);
+            IActionResult result = await _basketController.AddItems(slug, new AddItemsDTO { ItemIds = new[] { itemId } }, _ct);
 
             // Assert
             Assert.IsType<NotFoundResult>(result);
         }
 
         [Fact]
-        public async Task AddItem_WhenItemAlreadyExistsInBasket_ReturnsConflict()
+        public async Task AddItems_WhenAllItemsAlreadyInBasket_ReturnsOkWithUnchangedBasket()
         {
             // Arrange
             Guid userId = Guid.NewGuid();
@@ -377,19 +376,17 @@ namespace healthri_basket_api.test.Controller.Tests
             basket.AddItem(itemId);
 
             _basketServiceMock
-                .Setup(s => s.AddItemAsync(userId, slug, itemId, BasketItemSource.CatalogPage, _ct))
-                .ReturnsAsync((Basket?)null);
-            _basketServiceMock
-                .Setup(s => s.GetBySlugAsync(userId, slug, _ct))
+                .Setup(s => s.AddItemsAsync(userId, slug, It.IsAny<IEnumerable<string>>(), BasketItemSource.CatalogPage, _ct))
                 .ReturnsAsync(basket);
 
             SetAuthenticatedUser(userId);
 
             // Act
-            IActionResult result = await _basketController.AddItem(slug, itemId, _ct);
+            IActionResult result = await _basketController.AddItems(slug, new AddItemsDTO { ItemIds = new[] { itemId } }, _ct);
 
             // Assert
-            Assert.IsType<ConflictObjectResult>(result);
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(basket, okResult.Value);
         }
 
         [Fact]

--- a/healthri-basket-api.test/healthri-basket-api.test/Repositories.Tests/BasketRepositoryTests.cs
+++ b/healthri-basket-api.test/healthri-basket-api.test/Repositories.Tests/BasketRepositoryTests.cs
@@ -62,7 +62,7 @@ public class BasketRepositoryTests
     }
 
     [Fact]
-    public async Task AddItemAsync_WhenCalled_AddsBasketItem()
+    public async Task AddItemsAsync_WhenCalled_AddsBasketItem()
     {
         using var context = CreateContext();
         var repo = new BasketRepository(context);
@@ -72,10 +72,27 @@ public class BasketRepositoryTests
         await context.SaveChangesAsync();
 
         var basketItem = new BasketItem(basket, itemId);
-        await repo.AddItemAsync(basketItem, CancellationToken.None);
+        await repo.AddItemsAsync(new[] { basketItem }, CancellationToken.None);
 
         var exists = await context.BasketItems.AnyAsync(bi => bi.BasketId == basket.Id && bi.ItemId == itemId);
         Assert.True(exists);
+    }
+
+    [Fact]
+    public async Task AddItemsAsync_WhenMultipleItems_AddsAll()
+    {
+        using var context = CreateContext();
+        var repo = new BasketRepository(context);
+        var basket = new Basket(Guid.NewGuid(), "basket", "Basket", false);
+        context.Baskets.Add(basket);
+        await context.SaveChangesAsync();
+
+        var item1 = new BasketItem(basket, "item-1");
+        var item2 = new BasketItem(basket, "item-2");
+        await repo.AddItemsAsync(new[] { item1, item2 }, CancellationToken.None);
+
+        var count = await context.BasketItems.CountAsync(bi => bi.BasketId == basket.Id);
+        Assert.Equal(2, count);
     }
 
     [Fact]

--- a/healthri-basket-api.test/healthri-basket-api.test/Services.Tests/BasketServiceTests.cs
+++ b/healthri-basket-api.test/healthri-basket-api.test/Services.Tests/BasketServiceTests.cs
@@ -481,6 +481,25 @@ namespace healthri_basket_api.test.Services.Tests
         }
 
         [Fact]
+        public async Task AddItemsAsync_WhenItemIdsIsNull_ReturnsBasketUnchanged()
+        {
+            // Arrange
+            Guid basketId = Guid.NewGuid();
+            Basket basket = CreateBasketWithItems(basketId);
+            int originalCount = basket.Items.Count;
+            _basketRepositoryMock.Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct)).ReturnsAsync(basket);
+
+            // Act
+            var result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, null!, BasketItemSource.UserPage, _ct);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(originalCount, result.Items.Count);
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct), Times.Never);
+            _loggerMock.Verify(l => l.LogAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<BasketAction>(), It.IsAny<BasketItemSource>()), Times.Never);
+        }
+
+        [Fact]
         public async Task AddItemsAsync_WhenTransactionLogFails_ThrowsAndStillAddsItem()
         {
             // Arrange

--- a/healthri-basket-api.test/healthri-basket-api.test/Services.Tests/BasketServiceTests.cs
+++ b/healthri-basket-api.test/healthri-basket-api.test/Services.Tests/BasketServiceTests.cs
@@ -237,38 +237,34 @@ namespace healthri_basket_api.test.Services.Tests
         }
 
         [Fact]
-        public async Task AddItemAsync_WhenItemAndBasketExist_ReturnsUpdatedBasketAndAddsItem()
+        public async Task AddItemsAsync_WhenNewItem_ReturnsUpdatedBasket()
         {
             // Arrange
             Guid basketId = Guid.NewGuid();
             string itemId = "item-4";
             BasketItemSource source = BasketItemSource.CatalogPage;
 
-            // Mock basket (start empty)
             var basket = CreateBasketWithItems(basketId);
             basket.Items.Clear();
 
-            // Mock repository returns basket
             _basketRepositoryMock
                 .Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct))
                 .ReturnsAsync(basket);
 
-            // Mock AddItemAsync returns true
             _basketRepositoryMock
-                .Setup(r => r.AddItemAsync(It.IsAny<BasketItem>(), _ct))
+                .Setup(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct))
                 .ReturnsAsync(true);
 
-
             // Act
-            Basket? result = await _basketService.AddItemAsync(basket.UserId, basket.Slug, itemId, source, _ct);
+            Basket? result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, new[] { itemId }, source, _ct);
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(result.Items); // Expect 1 item added
+            Assert.Single(result.Items);
             Assert.Equal(itemId, result.Items.First().ItemId);
 
-            _basketRepositoryMock.Verify(r => r.AddItemAsync(It.Is<BasketItem>(
-                bi => bi.ItemId == itemId && bi.BasketId == basket.Id
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.Is<IEnumerable<BasketItem>>(
+                items => items.Single().ItemId == itemId && items.Single().BasketId == basket.Id
             ), _ct), Times.Once);
 
             _loggerMock.Verify(l => l.LogAsync(basket.UserId, basketId, itemId, BasketAction.AddItem, source), Times.Once);
@@ -409,7 +405,7 @@ namespace healthri_basket_api.test.Services.Tests
         }
 
         [Fact]
-        public async Task AddItemAsync_WhenBasketNotFound_ReturnsNull()
+        public async Task AddItemsAsync_WhenBasketNotFound_ReturnsNull()
         {
             // Arrange
             Guid userId = Guid.NewGuid();
@@ -418,16 +414,16 @@ namespace healthri_basket_api.test.Services.Tests
             _basketRepositoryMock.Setup(r => r.GetBySlugAsync(userId, slug, _ct)).ReturnsAsync((Basket?)null);
 
             // Act
-            var result = await _basketService.AddItemAsync(userId, slug, itemId, BasketItemSource.UserPage, _ct);
+            var result = await _basketService.AddItemsAsync(userId, slug, new[] { itemId }, BasketItemSource.UserPage, _ct);
 
             // Assert
             Assert.Null(result);
-            _basketRepositoryMock.Verify(r => r.AddItemAsync(It.IsAny<BasketItem>(), _ct), Times.Never);
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct), Times.Never);
             _loggerMock.Verify(l => l.LogAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<BasketAction>(), It.IsAny<BasketItemSource>()), Times.Never);
         }
 
         [Fact]
-        public async Task AddItemAsync_WhenUserMismatch_ReturnsNull()
+        public async Task AddItemsAsync_WhenUserMismatch_ReturnsNull()
         {
             // Arrange
             Guid userId = Guid.NewGuid();
@@ -437,52 +433,55 @@ namespace healthri_basket_api.test.Services.Tests
             _basketRepositoryMock.Setup(r => r.GetBySlugAsync(userId, slug, _ct)).ReturnsAsync(basket);
 
             // Act
-            var result = await _basketService.AddItemAsync(userId, slug, itemId, BasketItemSource.UserPage, _ct);
+            var result = await _basketService.AddItemsAsync(userId, slug, new[] { itemId }, BasketItemSource.UserPage, _ct);
 
             // Assert
             Assert.Null(result);
-            _basketRepositoryMock.Verify(r => r.AddItemAsync(It.IsAny<BasketItem>(), _ct), Times.Never);
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct), Times.Never);
             _loggerMock.Verify(l => l.LogAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<BasketAction>(), It.IsAny<BasketItemSource>()), Times.Never);
         }
 
         [Fact]
-        public async Task AddItemAsync_WhenItemAlreadyInBasket_ReturnsNull()
+        public async Task AddItemsAsync_WhenAllItemsAlreadyInBasket_ReturnsBasketUnchanged()
         {
             // Arrange
             Guid basketId = Guid.NewGuid();
             Basket basket = CreateBasketWithItems(basketId);
+            int originalCount = basket.Items.Count;
             string existingItemId = basket.Items.First().ItemId;
             _basketRepositoryMock.Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct)).ReturnsAsync(basket);
 
             // Act
-            var result = await _basketService.AddItemAsync(basket.UserId, basket.Slug, existingItemId, BasketItemSource.UserPage, _ct);
+            var result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, new[] { existingItemId }, BasketItemSource.UserPage, _ct);
 
             // Assert
-            Assert.Null(result);
-            _basketRepositoryMock.Verify(r => r.AddItemAsync(It.IsAny<BasketItem>(), _ct), Times.Never);
+            Assert.NotNull(result);
+            Assert.Equal(originalCount, result.Items.Count);
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct), Times.Never);
             _loggerMock.Verify(l => l.LogAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<BasketAction>(), It.IsAny<BasketItemSource>()), Times.Never);
         }
 
         [Fact]
-        public async Task AddItemAsync_WhenItemIdIsBlank_ReturnsNull()
+        public async Task AddItemsAsync_WhenAllItemIdsBlank_ReturnsBasketUnchanged()
         {
             // Arrange
             Guid basketId = Guid.NewGuid();
             Basket basket = CreateBasketWithItems(basketId);
-            string itemId = " ";
+            int originalCount = basket.Items.Count;
             _basketRepositoryMock.Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct)).ReturnsAsync(basket);
 
             // Act
-            var result = await _basketService.AddItemAsync(basket.UserId, basket.Slug, itemId, BasketItemSource.UserPage, _ct);
+            var result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, new[] { " " }, BasketItemSource.UserPage, _ct);
 
             // Assert
-            Assert.Null(result);
-            _basketRepositoryMock.Verify(r => r.AddItemAsync(It.IsAny<BasketItem>(), _ct), Times.Never);
+            Assert.NotNull(result);
+            Assert.Equal(originalCount, result.Items.Count);
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct), Times.Never);
             _loggerMock.Verify(l => l.LogAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<BasketAction>(), It.IsAny<BasketItemSource>()), Times.Never);
         }
 
         [Fact]
-        public async Task AddItemAsync_WhenTransactionLogFails_ThrowsAndStillAddsItem()
+        public async Task AddItemsAsync_WhenTransactionLogFails_ThrowsAndStillAddsItem()
         {
             // Arrange
             Guid basketId = Guid.NewGuid();
@@ -495,7 +494,7 @@ namespace healthri_basket_api.test.Services.Tests
                 .Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct))
                 .ReturnsAsync(basket);
             _basketRepositoryMock
-                .Setup(r => r.AddItemAsync(It.IsAny<BasketItem>(), _ct))
+                .Setup(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct))
                 .ReturnsAsync(true);
             _loggerMock
                 .Setup(l => l.LogAsync(basket.UserId, basket.Id, itemId, BasketAction.AddItem, source))
@@ -503,13 +502,76 @@ namespace healthri_basket_api.test.Services.Tests
 
             // Act
             var exception = await Assert.ThrowsAsync<Exception>(() =>
-                _basketService.AddItemAsync(basket.UserId, basket.Slug, itemId, source, _ct));
+                _basketService.AddItemsAsync(basket.UserId, basket.Slug, new[] { itemId }, source, _ct));
 
             // Assert
             Assert.Equal("logging down", exception.Message);
             Assert.Single(basket.Items);
             Assert.Equal(itemId, basket.Items.First().ItemId);
-            _basketRepositoryMock.Verify(r => r.AddItemAsync(It.IsAny<BasketItem>(), _ct), Times.Once);
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddItemsAsync_WhenMixedNewAndDuplicateItems_AddsOnlyNewOnes()
+        {
+            // Arrange
+            Guid basketId = Guid.NewGuid();
+            BasketItemSource source = BasketItemSource.CatalogPage;
+            Basket basket = CreateBasketWithItems(basketId);
+            string existingItemId = basket.Items.First().ItemId;
+            string newItemId = "item-new";
+            int originalCount = basket.Items.Count;
+
+            _basketRepositoryMock
+                .Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct))
+                .ReturnsAsync(basket);
+            _basketRepositoryMock
+                .Setup(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, new[] { existingItemId, newItemId }, source, _ct);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(originalCount + 1, result.Items.Count);
+            Assert.Contains(result.Items, i => i.ItemId == newItemId);
+
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.Is<IEnumerable<BasketItem>>(
+                items => items.Single().ItemId == newItemId
+            ), _ct), Times.Once);
+            _loggerMock.Verify(l => l.LogAsync(basket.UserId, basketId, newItemId, BasketAction.AddItem, source), Times.Once);
+            _loggerMock.Verify(l => l.LogAsync(basket.UserId, basketId, existingItemId, BasketAction.AddItem, source), Times.Never);
+        }
+
+        [Fact]
+        public async Task AddItemsAsync_WhenDuplicateIdsInInput_DeduplicatesAndAddsOnce()
+        {
+            // Arrange
+            Guid basketId = Guid.NewGuid();
+            BasketItemSource source = BasketItemSource.CatalogPage;
+            Basket basket = CreateBasketWithItems(basketId);
+            basket.Items.Clear();
+            string itemId = "item-new";
+
+            _basketRepositoryMock
+                .Setup(r => r.GetBySlugAsync(basket.UserId, basket.Slug, _ct))
+                .ReturnsAsync(basket);
+            _basketRepositoryMock
+                .Setup(r => r.AddItemsAsync(It.IsAny<IEnumerable<BasketItem>>(), _ct))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _basketService.AddItemsAsync(basket.UserId, basket.Slug, new[] { itemId, itemId }, source, _ct);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Single(result.Items);
+
+            _basketRepositoryMock.Verify(r => r.AddItemsAsync(It.Is<IEnumerable<BasketItem>>(
+                items => items.Count() == 1 && items.Single().ItemId == itemId
+            ), _ct), Times.Once);
+            _loggerMock.Verify(l => l.LogAsync(basket.UserId, basketId, itemId, BasketAction.AddItem, source), Times.Once);
         }
 
         [Fact]

--- a/healthri-basket-api/Controllers/BasketsController.cs
+++ b/healthri-basket-api/Controllers/BasketsController.cs
@@ -125,23 +125,13 @@ public class BasketsController(IBasketService service) : ControllerBase
     [HttpPost("{slug}/items")]
     [ProducesResponseType(typeof(Basket), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> AddItem(string slug, [FromBody] string itemId, CancellationToken ct)
+    public async Task<IActionResult> AddItems(string slug, [FromBody] AddItemsDTO dto, CancellationToken ct)
     {
         if (!TryGetUserId(out var userId, out var error))
             return error!;
-        var result = await service.AddItemAsync(userId, slug, itemId, BasketItemSource.CatalogPage, ct);
-        if (result != null)
-            return Ok(result);
-
-        // Service currently returns null for both "not found" and "already exists".
-        // Map duplicate add attempts to 409 to improve REST behavior.
-        var existingBasket = await service.GetBySlugAsync(userId, slug, ct);
-        if (existingBasket?.HasItem(itemId) == true)
-            return Conflict("Item already in basket.");
-
-        return NotFound();
+        var result = await service.AddItemsAsync(userId, slug, dto.ItemIds, BasketItemSource.CatalogPage, ct);
+        return result != null ? Ok(result) : NotFound();
     }
 
     [HttpDelete("{slug}/items")]

--- a/healthri-basket-api/Controllers/DTOs/AddItemsDTO.cs
+++ b/healthri-basket-api/Controllers/DTOs/AddItemsDTO.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace healthri_basket_api.Controllers.DTOs;
+
+public class AddItemsDTO
+{
+    [Required]
+    [MinLength(1, ErrorMessage = "At least one item ID is required.")]
+    public required IEnumerable<string> ItemIds { get; init; }
+}

--- a/healthri-basket-api/Interfaces/IBasketRepository.cs
+++ b/healthri-basket-api/Interfaces/IBasketRepository.cs
@@ -6,7 +6,7 @@ public interface IBasketRepository
 {
     Task<List<Basket>> GetByUserIdAsync(Guid userId, CancellationToken ct);
     Task<Basket?> GetBySlugAsync(Guid userId, string slug, CancellationToken ct);
-    Task<bool> AddItemAsync(BasketItem basketItem, CancellationToken ct);
+    Task<bool> AddItemsAsync(IEnumerable<BasketItem> basketItems, CancellationToken ct);
     Task<bool> RemoveItemAsync(BasketItem basketItem, CancellationToken ct);
     Task<Basket> CreateAsync(Basket basket, CancellationToken ct);
     Task<Basket> UpdateAsync(Basket basket, CancellationToken ct);

--- a/healthri-basket-api/Interfaces/IBasketService.cs
+++ b/healthri-basket-api/Interfaces/IBasketService.cs
@@ -13,6 +13,6 @@ public interface IBasketService
     Task<bool> RestoreAsync(Guid userId, string slug, CancellationToken ct);
     Task<bool> ArchiveAsync(Guid userId, string slug, CancellationToken ct);
     Task<bool> ClearAsync(Guid userId, string slug, CancellationToken ct);
-    Task<Basket?> AddItemAsync(Guid userId, string slug, string itemId, BasketItemSource source, CancellationToken ct);
+    Task<Basket?> AddItemsAsync(Guid userId, string slug, IEnumerable<string> itemIds, BasketItemSource source, CancellationToken ct);
     Task<bool> RemoveItemAsync(Guid userId, string slug, string itemId, BasketItemSource source, CancellationToken ct);
 }

--- a/healthri-basket-api/Repositories/BasketRepository.cs
+++ b/healthri-basket-api/Repositories/BasketRepository.cs
@@ -28,9 +28,9 @@ public class BasketRepository(AppDbContext context) : IBasketRepository
         return true;
     }
 
-    public async Task<bool> AddItemAsync(BasketItem basketItem, CancellationToken ct)
+    public async Task<bool> AddItemsAsync(IEnumerable<BasketItem> basketItems, CancellationToken ct)
     {
-        await context.BasketItems.AddAsync(basketItem, ct);
+        await context.BasketItems.AddRangeAsync(basketItems, ct);
         await context.SaveChangesAsync(ct);
         return true;
     }

--- a/healthri-basket-api/Services/BasketService.cs
+++ b/healthri-basket-api/Services/BasketService.cs
@@ -157,6 +157,9 @@ public class BasketService(
         if (basket == null || basket.UserId != userId)
             return null;
 
+        if (itemIds == null)
+            return basket;
+
         var newItems = itemIds
             .Where(id => !string.IsNullOrWhiteSpace(id) && !basket.HasItem(id))
             .Distinct()

--- a/healthri-basket-api/Services/BasketService.cs
+++ b/healthri-basket-api/Services/BasketService.cs
@@ -151,30 +151,27 @@ public class BasketService(
         return true;
     }
 
-    public async Task<Basket?> AddItemAsync(Guid userId, string slug, string itemId, BasketItemSource source, CancellationToken ct)
+    public async Task<Basket?> AddItemsAsync(Guid userId, string slug, IEnumerable<string> itemIds, BasketItemSource source, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(itemId))
-        {
-            return null;
-        }
-
         Basket? basket = await basketRepository.GetBySlugAsync(userId, slug, ct);
         if (basket == null || basket.UserId != userId)
             return null;
 
-        if (basket.HasItem(itemId))
-            return null;
+        var newItems = itemIds
+            .Where(id => !string.IsNullOrWhiteSpace(id) && !basket.HasItem(id))
+            .Distinct()
+            .Select(id => new BasketItem(basket, id))
+            .ToList();
 
-        BasketItem basketItem = new BasketItem(basket, itemId);
-
-        await basketRepository.AddItemAsync(basketItem, ct);
-
-        if (basket.Items.All(i => i.Id != basketItem.Id))
+        if (newItems.Count > 0)
         {
-            basket.Items.Add(basketItem);
+            await basketRepository.AddItemsAsync(newItems, ct);
+            foreach (var item in newItems)
+            {
+                basket.Items.Add(item);
+                await logger.LogAsync(basket.UserId, basket.Id, item.ItemId, BasketAction.AddItem, source);
+            }
         }
-
-        await logger.LogAsync(basket.UserId, basket.Id, itemId, BasketAction.AddItem, source);
 
         return basket;
     }

--- a/healthri-basket-api/Services/BasketService.cs
+++ b/healthri-basket-api/Services/BasketService.cs
@@ -171,7 +171,10 @@ public class BasketService(
             await basketRepository.AddItemsAsync(newItems, ct);
             foreach (var item in newItems)
             {
-                basket.Items.Add(item);
+                if (basket.Items.All(i => i.Id != item.Id))
+                {
+                    basket.Items.Add(item);
+                }
                 await logger.LogAsync(basket.UserId, basket.Id, item.ItemId, BasketAction.AddItem, source);
             }
         }


### PR DESCRIPTION
**Summary**

  - Replaces the POST /{slug}/items endpoint's with sinlge ItemID with AddItemsDTO { IEnumerable<string> ItemIds }, allowing to add one or more dataset IDs in a single request
  - Updates the service and repository layers to use AddItemsAsync / AddRangeAsync for batched persistence
  - Changes duplicate-item handling from returning null / 409 Conflict to silently skipping already-present or blank IDs 
  - Updates affected unit tests and adds new tests for the multi-item and deduplication behaviours

## Summary by Sourcery

Replace the single-item basket add flow with a multi-item add endpoint and batch persistence, while simplifying duplicate handling.

New Features:
- Introduce AddItemsAsync service method and AddItemsDTO to accept and process multiple item IDs in a single request.
- Expose a POST /{slug}/items controller action that accepts multiple item IDs and returns the updated basket.

Enhancements:
- Change duplicate and blank item handling to silently skip those IDs while still adding valid new items and returning the basket.
- Update basket repository to support batch insertion of basket items via AddItemsAsync/AddRangeAsync.
- Improve logging to record one add-item event per successfully added item during multi-item operations.
- Reformat docker-compose env_file section for consistency.

Tests:
- Update basket service, controller, and repository tests to cover multi-item add behavior, duplicate/blank ID handling, and batch persistence.