### PR TITLE
[codex] Guard basket item append after add range

### DIFF
--- a/healthri-basket-api/Services/BasketService.cs
+++ b/healthri-basket-api/Services/BasketService.cs
@@ -168,7 +168,10 @@ public class BasketService(
             await basketRepository.AddItemsAsync(newItems, ct);
             foreach (var item in newItems)
             {
-                basket.Items.Add(item);
+                if (basket.Items.All(i => i.Id != item.Id))
+                {
+                    basket.Items.Add(item);
+                }
                 await logger.LogAsync(basket.UserId, basket.Id, item.ItemId, BasketAction.AddItem, source);
             }
         }


### PR DESCRIPTION
## Summary

Adds a containment guard before appending newly added `BasketItem`s to the in-memory `basket.Items` collection.

## Why

`AddItemsAsync(newItems, ct)` persists the rows, and EF tracking may also update the loaded `basket.Items` relationship through fixup. The guard keeps the response correct in both cases: if EF already attached the item, it avoids a duplicate; if not, it still adds the item to the returned basket object.

## Validation

- `dotnet test healthri-basket-api.test/healthri-basket-api.test/healthri-basket-api.test.csproj --no-restore`

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate BasketItem entries in the in-memory basket.Items collection when EF relationship fixup has already attached newly added items.